### PR TITLE
Add GET /about API support

### DIFF
--- a/Sources/GoogleDriveClient/About.swift
+++ b/Sources/GoogleDriveClient/About.swift
@@ -1,0 +1,27 @@
+public struct About: Sendable, Equatable, Codable {
+  public init(
+    storageQuota: StorageQuota,
+    appInstalled: Bool,
+    maxUploadSize: String,
+    user: User
+  ) {
+    self.storageQuota = storageQuota
+    self.appInstalled = appInstalled
+    self.maxUploadSize = maxUploadSize
+    self.user = user
+  }
+
+  public var storageQuota: StorageQuota
+  public var appInstalled: Bool
+  public var maxUploadSize: String
+  public var user: User
+}
+
+extension About {
+  static let apiFields: String = [
+    "storageQuota(" + StorageQuota.apiFields + ")",
+    "appInstalled",
+    "maxUploadSize",
+    "user(" + User.apiFields + ")",
+  ].joined(separator: ",")
+}

--- a/Sources/GoogleDriveClient/Client.swift
+++ b/Sources/GoogleDriveClient/Client.swift
@@ -3,6 +3,7 @@ import Foundation
 public struct Client: Sendable {
   public init(
     auth: Auth,
+    getAbout: GetAbout,
     listFiles: ListFiles,
     getFile: GetFile,
     getFileData: GetFileData,
@@ -11,6 +12,7 @@ public struct Client: Sendable {
     deleteFile: DeleteFile
   ) {
     self.auth = auth
+    self.getAbout = getAbout
     self.listFiles = listFiles
     self.getFile = getFile
     self.getFileData = getFileData
@@ -20,6 +22,7 @@ public struct Client: Sendable {
   }
 
   public var auth: Auth
+  public var getAbout: GetAbout
   public var listFiles: ListFiles
   public var getFile: GetFile
   public var getFileData: GetFileData
@@ -42,6 +45,11 @@ extension Client {
       keychain: keychain,
       dateGenerator: dateGenerator,
       openURL: openURL,
+      httpClient: httpClient
+    )
+    let getAbout = GetAbout.live(
+      auth: auth,
+      keychain: keychain,
       httpClient: httpClient
     )
     let listFiles = ListFiles.live(
@@ -78,6 +86,7 @@ extension Client {
     )
     return Client(
       auth: auth,
+      getAbout: getAbout,
       listFiles: listFiles,
       getFile: getFile,
       getFileData: getFileData,

--- a/Sources/GoogleDriveClient/GetAbout.swift
+++ b/Sources/GoogleDriveClient/GetAbout.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+public struct GetAbout: Sendable {
+  public enum Error: Swift.Error, Sendable, Equatable {
+    case notAuthorized
+    case response(statusCode: Int?, data: Data)
+  }
+
+  public typealias Run = @Sendable () async throws -> About
+
+  public init(run: @escaping Run) {
+    self.run = run
+  }
+
+  public var run: Run
+
+  public func callAsFunction() async throws -> About {
+    try await run()
+  }
+}
+
+extension GetAbout {
+  public static func live(
+    auth: Auth,
+    keychain: Keychain,
+    httpClient: HTTPClient
+  ) -> GetAbout {
+    GetAbout {
+      try await auth.refreshToken()
+
+      guard let credentials = await keychain.loadCredentials() else {
+        throw Error.notAuthorized
+      }
+
+      let request: URLRequest = {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "www.googleapis.com"
+        components.path = "/drive/v3/about"
+        components.queryItems = [
+          URLQueryItem(name: "fields", value: About.apiFields),
+        ]
+
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = "GET"
+        request.setValue(
+          "\(credentials.tokenType) \(credentials.accessToken)",
+          forHTTPHeaderField: "Authorization"
+        )
+
+        return request
+      }()
+
+      let (responseData, response) = try await httpClient.data(for: request)
+      let statusCode = (response as? HTTPURLResponse)?.statusCode
+
+      guard let statusCode, (200..<300).contains(statusCode) else {
+        throw Error.response(statusCode: statusCode, data: responseData)
+      }
+
+      return try JSONDecoder.api.decode(About.self, from: responseData)
+    }
+  }
+}

--- a/Sources/GoogleDriveClient/StorageQuota.swift
+++ b/Sources/GoogleDriveClient/StorageQuota.swift
@@ -1,0 +1,19 @@
+public struct StorageQuota: Sendable, Equatable, Codable {
+  public init(
+    limit: String,
+    usage: String
+  ) {
+    self.limit = limit
+    self.usage = usage
+  }
+
+  public var limit: String
+  public var usage: String
+}
+
+extension StorageQuota {
+  static let apiFields: String = [
+    "limit",
+    "usage",
+  ].joined(separator: ",")
+}

--- a/Sources/GoogleDriveClient/User.swift
+++ b/Sources/GoogleDriveClient/User.swift
@@ -1,0 +1,23 @@
+public struct User: Sendable, Equatable, Codable {
+  public init(
+    displayName: String,
+    emailAddress: String,
+    photoLink: String
+  ) {
+    self.displayName = displayName
+    self.emailAddress = emailAddress
+    self.photoLink = photoLink
+  }
+      
+  public var displayName: String
+  public var emailAddress: String
+  public var photoLink: String
+}
+
+extension User {
+  static let apiFields: String = [
+    "displayName",
+    "emailAddress",
+    "photoLink",
+  ].joined(separator: ",")
+}

--- a/Tests/GoogleDriveClientTests/GetAboutTests.swift
+++ b/Tests/GoogleDriveClientTests/GetAboutTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import GoogleDriveClient
+
+final class GetAboutTests: XCTestCase {
+  func testGetAbout() async throws {
+    let credentials = Credentials(
+      accessToken: "access-token-1",
+      expiresAt: Date(),
+      refreshToken: "refresh-token-1",
+      tokenType: "token-type-1"
+    )
+    let httpRequests = ActorIsolated<[URLRequest]>([])
+    let didRefreshToken = ActorIsolated(0)
+    let GetAbout = GetAbout.live(
+      auth: {
+        var auth = Auth.unimplemented()
+        auth.refreshToken = {
+          await didRefreshToken.withValue { $0 += 1 }
+        }
+        return auth
+      }(),
+      keychain: {
+        var keychain = Keychain.unimplemented()
+        keychain.loadCredentials = { credentials }
+        return keychain
+      }(),
+      httpClient: .init { request in
+        await httpRequests.withValue { $0.append(request) }
+        return (
+          """
+          {
+            "user": {
+              "displayName": "Test User",
+              "photoLink": "https://lh3.googleusercontent.com/a/fake_hash",
+              "emailAddress": "user@test.com"
+            },
+            "storageQuota": {
+              "limit": "1000000000000",
+              "usage": "70000000000"
+            },
+            "maxUploadSize": "5242880000000",
+            "appInstalled": true
+          }
+          """.data(using: .utf8)!,
+          HTTPURLResponse(
+            url: URL(filePath: "/"),
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+          )!
+        )
+      }
+    )
+
+    let about = try await GetAbout()
+
+    await didRefreshToken.withValue {
+      XCTAssertEqual($0, 1)
+    }
+    await httpRequests.withValue {
+      let url = URL(string: "https://www.googleapis.com/drive/v3/about")!
+      var expectedRequest = URLRequest(url: url)
+      expectedRequest.httpMethod = "GET"
+      expectedRequest.allHTTPHeaderFields = [
+        "Authorization": "\(credentials.tokenType) \(credentials.accessToken)"
+      ]
+      XCTAssertEqual($0, [expectedRequest])
+      XCTAssertNil($0.first?.httpBody)
+    }
+    XCTAssertEqual(about, About(
+      storageQuota: StorageQuota(
+        limit: "1000000000000",
+        usage: "70000000000"
+      ),
+      appInstalled: true,
+      maxUploadSize: "5242880000000",
+      user: User(
+        displayName: "Test User",
+        emailAddress: "user@test.com",
+        photoLink: "https://lh3.googleusercontent.com/a/fake_hash"
+      )
+    ))
+  }
+
+  func testGetAboutErrorResponse() async {
+    let GetAbout = GetAbout.live(
+      auth: {
+        var auth = Auth.unimplemented()
+        auth.refreshToken = {}
+        return auth
+      }(),
+      keychain: {
+        var keychain = Keychain.unimplemented()
+        keychain.loadCredentials = {
+          Credentials(
+            accessToken: "",
+            expiresAt: Date(),
+            refreshToken: "",
+            tokenType: ""
+          )
+        }
+        return keychain
+      }(),
+      httpClient: .init { request in
+        (
+          "Error!!!".data(using: .utf8)!,
+          HTTPURLResponse(
+            url: URL(filePath: "/"),
+            statusCode: 500,
+            httpVersion: nil,
+            headerFields: nil
+          )!
+        )
+      }
+    )
+
+    do {
+      _ = try await GetAbout()
+      XCTFail("Expected to throw, but didn't")
+    } catch {
+      XCTAssertEqual(
+        error as? GetAbout.Error,
+        .response(
+          statusCode: 500,
+          data: "Error!!!".data(using: .utf8)!
+        ),
+        "Expected to throw response error, got \(error)"
+      )
+    }
+  }
+
+  func testGetAboutWhenNotAuthorized() async {
+    let GetAbout = GetAbout.live(
+      auth: {
+        var auth = Auth.unimplemented()
+        auth.refreshToken = {}
+        return auth
+      }(),
+      keychain: {
+        var keychain = Keychain.unimplemented()
+        keychain.loadCredentials = { nil }
+        return keychain
+      }(),
+      httpClient: .unimplemented()
+    )
+
+    do {
+      _ = try await GetAbout()
+      XCTFail("Expected to throw, but didn't")
+    } catch {
+      XCTAssertEqual(
+        error as? GetAbout.Error, .notAuthorized,
+        "Expected to throw .notAuthorized, got \(error)"
+      )
+    }
+  }
+}

--- a/Tests/GoogleDriveClientTests/GetAboutTests.swift
+++ b/Tests/GoogleDriveClientTests/GetAboutTests.swift
@@ -58,7 +58,7 @@ final class GetAboutTests: XCTestCase {
       XCTAssertEqual($0, 1)
     }
     await httpRequests.withValue {
-      let url = URL(string: "https://www.googleapis.com/drive/v3/about")!
+      let url = URL(string: "https://www.googleapis.com/drive/v3/about?fields=\(About.apiFields)")!
       var expectedRequest = URLRequest(url: url)
       expectedRequest.httpMethod = "GET"
       expectedRequest.allHTTPHeaderFields = [


### PR DESCRIPTION
Hi thanks for this project!

I'm trying to use the [`about.get` API](https://developers.google.com/drive/api/reference/rest/v3/about/get) to load some information about the user, so I thought I'd go ahead and submit a PR to make that an option in the library.

I tried to follow all the existing conventions and added tests as well (although I did not add this function to the example app). I also verified all tests (including old tests) pass.

![test results](https://github.com/darrarski/swift-google-drive-client/assets/635005/4f503f3f-5262-4fbc-b7ae-43a0583bdc69)
